### PR TITLE
Get the simulator to compile under Windows

### DIFF
--- a/src/cdsem/cuda_kernels.cu
+++ b/src/cdsem/cuda_kernels.cu
@@ -9,8 +9,8 @@
 #include <common/cuda_make_ptr.cuh>
 #include <common/cuda_vec3_math.cuh>
  
-const float eps = 10.0f*FLT_EPSILON;
-const float mc2 = 5.1099897e+05f;
+__device__ const float eps = 10.0f*FLT_EPSILON;
+__device__ const float mc2 = 5.1099897e+05f;
 
 /*
 namespace fermi_sea {

--- a/src/cdsem/main.cu
+++ b/src/cdsem/main.cu
@@ -84,7 +84,7 @@ int main(const int argc, char* argv[]) {
         std::clog << " index=" << mat_vec.size();
         std::clog << " file='" << mat_file << "'";
         std::clog << std::endl;
-        std::ifstream ifs(mat_file);
+        std::ifstream ifs(mat_file, std::ifstream::in | std::ifstream::binary);
         if(!ifs.is_open())
             throw std::ios_base::failure("failed to open '"+mat_file+"' for reading");
         archive::istream ia(ifs);

--- a/src/cdsem/main.cu
+++ b/src/cdsem/main.cu
@@ -25,8 +25,9 @@
 const int cuda_warp_size = 32;
 const int cuda_block_size = cuda_warp_size*4;
 
-class {
+class sc {
 public:
+	sc() : _cursor_vec(std::vector<char>{ '|', '/', '-', '\\' }) {}
     void reset() {
        _cursor_index = 0;
     }
@@ -37,7 +38,7 @@ public:
         std::clog << "    \r [*]";
     }
 private:
-    std::vector<char> _cursor_vec = {'|', '/', '-', '\\'};
+    std::vector<char> _cursor_vec;
     size_t _cursor_index = 0;
 } spin_cursor;
 

--- a/src/common/constant.hh
+++ b/src/common/constant.hh
@@ -14,7 +14,7 @@ namespace constant {
 /*!
  * pi
  */
-const double pi = M_PI;
+const double pi = 3.14159265359;
 /*!
  * speed of light
  */

--- a/src/common/xml.cc
+++ b/src/common/xml.cc
@@ -7,6 +7,7 @@
 #include <common/xml.hh>
 #include <sstream>
 #include <stack>
+#include <cctype>
 
 namespace xml {
 


### PR DESCRIPTION
Some minor changes that should not break the simulator under gcc.

One commit makes the code more standards-compliant, the second commit actually changes correct syntax.
