### PR TITLE
Get code to compile in VS

### DIFF
--- a/src/cdsem/octree.cc
+++ b/src/cdsem/octree.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <limits>
 #include <stack>
+#include <algorithm>
 #include "point3.hh"
 #include "tribox.hh"
 


### PR DESCRIPTION
VS does not define std::min and std::max unless you explicitly include <algorithm>.
